### PR TITLE
Removing scrollX from the base.html

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -57,8 +57,7 @@
         var table = $("#{{ s3objects.table_id }}").DataTable( {
             "paging": true,
             "pageLength": 50,
-            "lengthChange": false,
-            "scrollX": true
+            "lengthChange": false
         } );
     } );
 {% endif %}


### PR DESCRIPTION
scrollX option breaks the file list displayed.